### PR TITLE
Fix sample post handling in PostsLoader

### DIFF
--- a/js/postsLoader.js
+++ b/js/postsLoader.js
@@ -86,6 +86,16 @@ class PostsLoader {
       // Create sample posts for testing
       this.posts = this.createSamplePosts();
       console.log('Using sample posts instead:', this.posts.length);
+
+      // Extract unique categories from sample posts
+      this.posts.forEach(post => {
+        if (post.category) {
+          this.categories.add(post.category);
+        }
+      });
+
+      // Sort sample posts by date (newest first)
+      this.posts.sort((a, b) => new Date(b.date) - new Date(a.date));
     }
   }
 


### PR DESCRIPTION
## Summary
- ensure sample posts populate categories and remain sorted when JSON fetch fails

## Testing
- `node --check js/postsLoader.js`


------
https://chatgpt.com/codex/tasks/task_e_68408f0938b48331b76f7efd52513fd9